### PR TITLE
fix: prevent commenting and auto-closing bot PRs

### DIFF
--- a/.github/scripts/linked_issue_enforce.js
+++ b/.github/scripts/linked_issue_enforce.js
@@ -8,6 +8,9 @@ const requireAuthorAssigned = (process.env.REQUIRE_AUTHOR_ASSIGNED || 'true').to
 const getDaysOpen = (pr) =>
   Math.floor((Date.now() - new Date(pr.created_at)) / (24 * 60 * 60 * 1000));
 
+// Check if the PR author is a bot
+const isBotAuthor = (pr) => pr.user?.type === 'Bot';
+
 // Check if the PR author is assigned to the issue
 const isAuthorAssigned = (issue, login) => {
   if (!issue || issue.state?.toUpperCase() !== 'OPEN') return false;
@@ -104,6 +107,12 @@ module.exports = async ({ github, context }) => {
     console.log(`Evaluating ${prs.length} open PRs\n`);
 
     for (const pr of prs) {
+
+      if (isBotAuthor(pr)) {
+        console.log(`PR #${pr.number} authored by bot (${pr.user.login}). Skipping.`);
+        continue;
+      }
+
       const days = getDaysOpen(pr);
       if (days < daysBeforeClose) {
         console.log(`PR #${pr.number} link: ${pr.html_url} is only ${days} days old. Skipping.`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Enhance TopicInfo `__str__` method and tests with additional coverage, and update the format_key function in `key_format.py` to handle objects with a _to_proto method.
 
 ### Fixed
+- Prevented linkbot from commenting on or auto-closing bot-authored pull requests. (#1516)
 - Respect `dry-run` input in `bot-community-calls.yml` workflow (#1425)
 - Updated LinkBot regex in the GitHub Actions bot script to support "Closes" and "Resolves" keywords for improved PR body-link detection (#1465)
 - Fixed CodeRabbit plan trigger workflow running multiple times when issues are created with multiple labels by switching to labeled event trigger only. (#1427)


### PR DESCRIPTION
This is a pr to test linkbot commenting on bot PRs or auto-closing them