### PR TITLE
fix: Change logging to error throwing for unrecognized labels

### DIFF
--- a/.github/scripts/shared/core/issue-assign.js
+++ b/.github/scripts/shared/core/issue-assign.js
@@ -142,8 +142,9 @@ async function runAssignmentFlow({ github, context }) {
 
   const levelKey = resolveLevelKey(issue, repoConfig);
   if (!levelKey) {
-    console.log(`[assign-bot] Issue #${issue.number} has no recognized skill label. Exiting.`);
-    return;
+    throw new Error(
+      `[assign-bot] Issue #${issue.number} has no recognized skill label.`
+    );
   }
 
   const levelConfig = CONFIG.skillPrerequisites[levelKey];


### PR DESCRIPTION
Throw an error instead of logging when no recognized skill label is found.